### PR TITLE
add "test" environment

### DIFF
--- a/manifests/webserver.pp
+++ b/manifests/webserver.pp
@@ -11,7 +11,7 @@ class diaspora::webserver (
     members => ['localhost:3000']
   }
 
-  if $environment == 'development' {
+  if ($environment == 'development') or ($environment == 'test') {
     nginx::resource::vhost { $hostname:
       ensure      => present,
       proxy       => 'http://diaspora_server',


### PR DESCRIPTION
diaspora* has a "test" environment besides "development" and "production". The "test" environment on the webserver level may just repeat the "development" environment.