### PR TITLE
Development version should embed sidekiq

### DIFF
--- a/templates/diaspora.yml.erb
+++ b/templates/diaspora.yml.erb
@@ -17,7 +17,7 @@ configuration: ## Section
     ## Require SSL (default=true).
     require_ssl: false
 
-    single_process_mode: false
+    single_process_mode: <%= @environment != "production" %>
 
     ## Sidekiq - background processing
     sidekiq: ## Section


### PR DESCRIPTION
This is how diaspora now set by default. In that mode it's more predictable and better fits for testing.